### PR TITLE
Keep package-managed directory

### DIFF
--- a/ansible/roles/dp3/tasks/dp3/configure_dp3.yml
+++ b/ansible/roles/dp3/tasks/dp3/configure_dp3.yml
@@ -2,7 +2,7 @@
   become: true
   ansible.builtin.shell: |
     set -o pipefail
-    rm -rf /opt/adict && rm -rf /etc/{{ app_name }} && rm -rf /var/run/{{ app_name }}
+    rm -rf /etc/{{ app_name }} && rm -rf /var/run/{{ app_name }}
     SERVICE_NAME="{{ app_name }}"
     if systemctl --all --type=service | grep -q "$SERVICE_NAME"; then
         systemctl stop "$SERVICE_NAME"


### PR DESCRIPTION
Removing directory managed by the package breaks subsequent playbook runs.