### PR TITLE
Conditional installation of ADiCT

### DIFF
--- a/ansible/inventory/host_files/192.168.56.10/pandda.yaml
+++ b/ansible/inventory/host_files/192.168.56.10/pandda.yaml
@@ -2,8 +2,8 @@
     port: 4739
     proto: "TCP"
     forward_targets:
-      - { host: "host1.liberouter.org", port: 4739, proto: "TCP" }
-      - { host: "host2.liberouter.org", port: 4739, proto: "UDP" }
+      - { host: "192.168.56.20", port: 4739, proto: "TCP" }
+      - { host: "192.168.56.30", port: 4739, proto: "UDP" }
 - adict:
     protected_prefixes:
       - 192.168.100.0/24

--- a/ansible/inventory/host_vars/192.168.56.10/pandda_vars.yml
+++ b/ansible/inventory/host_vars/192.168.56.10/pandda_vars.yml
@@ -1,1 +1,2 @@
 install_adict: true
+remove_adict: true

--- a/ansible/inventory/host_vars/192.168.56.10/pandda_vars.yml
+++ b/ansible/inventory/host_vars/192.168.56.10/pandda_vars.yml
@@ -1,2 +1,4 @@
-install_adict: true
 remove_adict: true
+install_adict: true
+enable_adict: true
+disable_adict: false

--- a/ansible/inventory/host_vars/192.168.56.10/pandda_vars.yml
+++ b/ansible/inventory/host_vars/192.168.56.10/pandda_vars.yml
@@ -1,0 +1,1 @@
+install_adict: true

--- a/ansible/pandda.yml
+++ b/ansible/pandda.yml
@@ -14,7 +14,5 @@
     - pandda_conf
     - common_tools
     - nemea_collector
-    - pandda_gui
-    - dp3
-    - nemea_adict
+    - adict
     - supervisor_restart

--- a/ansible/roles/adict/meta/main.yml
+++ b/ansible/roles/adict/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: adict_vars

--- a/ansible/roles/adict/tasks/install.yml
+++ b/ansible/roles/adict/tasks/install.yml
@@ -1,0 +1,12 @@
+---
+- name: Install pandda_gui if ADiCT installation is enabled
+  ansible.builtin.include_role:
+    name: pandda_gui
+
+- name: Install dp3 if ADiCT installation is enabled
+  ansible.builtin.include_role:
+    name: dp3
+
+- name: Install nemea_adict if ADiCT installation is enabled
+  ansible.builtin.include_role:
+    name: nemea_adict

--- a/ansible/roles/adict/tasks/install.yml
+++ b/ansible/roles/adict/tasks/install.yml
@@ -6,6 +6,7 @@
 - name: Install dp3 if ADiCT installation is enabled
   ansible.builtin.include_role:
     name: dp3
+  when: dp3_role_has_run_already is not defined
 
 - name: Install nemea_adict if ADiCT installation is enabled
   ansible.builtin.include_role:

--- a/ansible/roles/adict/tasks/main.yml
+++ b/ansible/roles/adict/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Remove ADiCT  when removal is enabled
+  ansible.builtin.include_tasks: remove.yml
+  when: remove_adict
+
 - name: Install ADiCT when installation is enabled
   ansible.builtin.include_tasks: install.yml
   when: install_adict

--- a/ansible/roles/adict/tasks/main.yml
+++ b/ansible/roles/adict/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Install ADiCT when installation is enabled
+  ansible.builtin.include_tasks: install.yml
+  when: install_adict

--- a/ansible/roles/adict/tasks/remove.yml
+++ b/ansible/roles/adict/tasks/remove.yml
@@ -1,0 +1,14 @@
+---
+- name: Remove nemea_adict if enabled
+  ansible.builtin.include_role:
+    name: nemea_adict_remove
+
+- name: Remove dp3 if enabled
+  ansible.builtin.include_role:
+    name: dp3_remove
+
+- name: Remove PANDDA GUI package if enabled
+  ansible.builtin.dnf:
+    name: pandda_gui
+    state: absent
+    autoremove: false

--- a/ansible/roles/adict_vars/tasks/main.yml
+++ b/ansible/roles/adict_vars/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Set install_adict if not defined to default value
+  ansible.builtin.set_fact:
+    install_adict: "{{ install_adict | default(false) | bool }}"
+
 - name: Set etcdir if not defined to default value
   ansible.builtin.set_fact:
     etcdir: "{{ etcdir | default('adict') }}"
@@ -30,6 +34,7 @@
 - name: Print ADICT variables
   ansible.builtin.debug:
     msg:
+      - "install_adict: {{ install_adict }}"
       - "etcdir: {{ etcdir }}"
       - "installdir: {{ installdir }}"
       - "venvdir: {{ venvdir }}"

--- a/ansible/roles/adict_vars/tasks/main.yml
+++ b/ansible/roles/adict_vars/tasks/main.yml
@@ -7,6 +7,14 @@
   ansible.builtin.set_fact:
     remove_adict: "{{ remove_adict | default(false) | bool }}"
 
+- name: Set disable_adict if not defined to default value
+  ansible.builtin.set_fact:
+    disable_adict: "{{ disable_adict | default(false) | bool }}"
+
+- name: Set enable_adict if not defined to default value
+  ansible.builtin.set_fact:
+    enable_adict: "{{ enable_adict | default(install_adict) | bool }}"
+
 - name: Set etcdir if not defined to default value
   ansible.builtin.set_fact:
     etcdir: "{{ etcdir | default('adict') }}"
@@ -40,6 +48,8 @@
     msg:
       - "remove_adict: {{ remove_adict }}"
       - "install_adict: {{ install_adict }}"
+      - "disable_adict: {{ disable_adict }}"
+      - "enable_adict: {{ enable_adict }}"
       - "etcdir: {{ etcdir }}"
       - "installdir: {{ installdir }}"
       - "venvdir: {{ venvdir }}"

--- a/ansible/roles/adict_vars/tasks/main.yml
+++ b/ansible/roles/adict_vars/tasks/main.yml
@@ -3,6 +3,10 @@
   ansible.builtin.set_fact:
     install_adict: "{{ install_adict | default(false) | bool }}"
 
+- name: Set remove_adict if not defined to default value
+  ansible.builtin.set_fact:
+    remove_adict: "{{ remove_adict | default(false) | bool }}"
+
 - name: Set etcdir if not defined to default value
   ansible.builtin.set_fact:
     etcdir: "{{ etcdir | default('adict') }}"
@@ -34,6 +38,7 @@
 - name: Print ADICT variables
   ansible.builtin.debug:
     msg:
+      - "remove_adict: {{ remove_adict }}"
       - "install_adict: {{ install_adict }}"
       - "etcdir: {{ etcdir }}"
       - "installdir: {{ installdir }}"

--- a/ansible/roles/dp3/tasks/dp3/configure_dp3.yml
+++ b/ansible/roles/dp3/tasks/dp3/configure_dp3.yml
@@ -78,18 +78,12 @@
   ansible.builtin.systemd:
     daemon_reload: true
 
-- name: Start and enable application
-  ansible.builtin.systemd:
-    name: "{{ app_name }}"
-    state: restarted
-    enabled: true
+- name: Stop and disable application
+  ansible.builtin.include_tasks: disable.yml
+  tags: configure
+  when: disable_adict
 
-- name: Ensure application is running
-  community.general.supervisorctl:
-    name: "{{ item }}"
-    state: restarted
-    config: /etc/{{ app_name }}/supervisord.conf
-  with_items:
-    - api
-    - w:worker0
-    - ecl_master
+- name: Start and enable application
+  ansible.builtin.include_tasks: enable.yml
+  tags: configure
+  when: enable_adict

--- a/ansible/roles/dp3/tasks/dp3/disable.yml
+++ b/ansible/roles/dp3/tasks/dp3/disable.yml
@@ -1,0 +1,25 @@
+---
+- name: Stop application if running
+  community.general.supervisorctl:
+    name: "{{ item }}"
+    state: stopped
+    config: /etc/{{ app_name }}/supervisord.conf
+  with_items:
+    - api
+    - w:worker0
+    - ecl_master
+  failed_when: false
+
+- name: Stop and disable application
+  ansible.builtin.systemd:
+    name: "{{ app_name }}"
+    state: stopped
+    enabled: false
+  failed_when: false
+
+- name: Stop and disable redis service
+  ansible.builtin.service:
+    name: redis
+    state: stopped
+    enabled: false
+  failed_when: false

--- a/ansible/roles/dp3/tasks/dp3/enable.yml
+++ b/ansible/roles/dp3/tasks/dp3/enable.yml
@@ -1,0 +1,22 @@
+---
+- name: Start and enable redis service
+  ansible.builtin.service:
+    name: redis
+    state: started
+    enabled: true
+
+- name: Start and enable application
+  ansible.builtin.systemd:
+    name: "{{ app_name }}"
+    state: restarted
+    enabled: true
+
+- name: Ensure application is running
+  community.general.supervisorctl:
+    name: "{{ item }}"
+    state: restarted
+    config: /etc/{{ app_name }}/supervisord.conf
+  with_items:
+    - api
+    - w:worker0
+    - ecl_master

--- a/ansible/roles/dp3/tasks/dp3/install_dp3.yml
+++ b/ansible/roles/dp3/tasks/dp3/install_dp3.yml
@@ -3,12 +3,6 @@
     name: ["redis", "socat", "logrotate"]
     state: present
 
-- name: Start and enable redis service
-  ansible.builtin.service:
-    name: redis
-    state: started
-    enabled: true
-
 - name: Create Python virtual environment for DP3
   ansible.builtin.command:
     cmd: python3.9 -m venv {{ venvdir }}

--- a/ansible/roles/dp3/tasks/main.yml
+++ b/ansible/roles/dp3/tasks/main.yml
@@ -4,3 +4,7 @@
 
 - name: Configure DP3
   ansible.builtin.import_tasks: ./dp3/configure_dp3.yml
+
+- name: Register that DP3 is installed and configured
+  ansible.builtin.set_fact:
+    dp3_role_has_run_already: true

--- a/ansible/roles/dp3_remove/meta/main.yaml
+++ b/ansible/roles/dp3_remove/meta/main.yaml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - role: mongodb_remove
+  - role: rabbitmq_remove
+  - role: nginx_remove

--- a/ansible/roles/dp3_remove/tasks/main.yml
+++ b/ansible/roles/dp3_remove/tasks/main.yml
@@ -1,0 +1,73 @@
+---
+- name: Stop and disable application
+  ansible.builtin.systemd:
+    name: "{{ app_name }}"
+    state: stopped
+    enabled: false
+  failed_when: false
+  tags: uninstall
+
+- name: Remove PANDDA ADiCT package
+  ansible.builtin.dnf:
+    name: pandda_adict
+    state: absent
+    autoremove: false
+  tags: uninstall
+
+- name: Remove application and configuration to create clean environment
+  become: true
+  ansible.builtin.shell: |
+    set -o pipefail
+    rm -rf /etc/{{ app_name }} && rm -rf /var/run/{{ app_name }} && rm -rf /data/datapoints && rm -rf /var/log/{{ app_name }}
+    SERVICE_NAME="{{ app_name }}"
+    if systemctl --all --type=service | grep -q "$SERVICE_NAME"; then
+        systemctl stop "$SERVICE_NAME"
+        systemctl disable "$SERVICE_NAME"
+        rm "/etc/systemd/system/${SERVICE_NAME}.service"
+        rm -f /usr/bin/${SERVICE_NAME}ctl
+        systemctl daemon-reload
+        systemctl reset-failed
+    fi
+  changed_when: true
+  tags: uninstall
+
+- name: Reload units
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true
+  tags: uninstall
+
+- name: Remove user
+  ansible.builtin.user:
+    name: "{{ app_name }}"
+    group: "{{ app_name }}"
+    state: absent
+    shell: /bin/bash
+    createhome: true
+  tags: uninstall
+
+- name: Remove group
+  ansible.builtin.group:
+    name: "{{ app_name }}"
+    state: absent
+  tags: uninstall
+
+- name: Stop and disable redis service
+  ansible.builtin.service:
+    name: redis
+    state: stopped
+    enabled: false
+  failed_when: false
+  tags: uninstall
+
+- name: Remove dependencies for dp3
+  ansible.builtin.dnf:
+    name: ["redis", "socat"]
+    state: present
+  tags: uninstall
+
+- name: Remove Python virtual environment for DP3
+  ansible.builtin.file:
+    path: "{{ venvdir }}"
+    state: absent
+  tags: uninstall

--- a/ansible/roles/ipfixcol2/tasks/main.yml
+++ b/ansible/roles/ipfixcol2/tasks/main.yml
@@ -15,10 +15,10 @@
     - install
     - configure
 
+  # creates: /etc/ipfixcol2/ipfixcol2-startup.xml
 - name: IPFIXcol2 configuration file is created from pandda.yml
   ansible.builtin.command:
     cmd: "{{ pandda_conf_executable }} {{ pandda_conf_opt }}/ipfixcol2_conf.py -f /etc/ipfixcol2/ipfixcol2-startup.xml"
-    creates: /etc/ipfixcol2/ipfixcol2-startup.xml
   changed_when: true
   tags:
     - install

--- a/ansible/roles/mongodb/tasks/main.yml
+++ b/ansible/roles/mongodb/tasks/main.yml
@@ -28,8 +28,18 @@
   ansible.builtin.systemd:
     daemon_reload: true
 
+- name: Disable MongoDB container
+  ansible.builtin.systemd:
+    name: mongodb-{{ app_name }}
+    state: stopped
+    enabled: false
+  failed_when: false
+  when: disable_adict
+  tags: configure
+
 - name: Start MongoDB container
   ansible.builtin.systemd:
     name: mongodb-{{ app_name }}
     state: started
     enabled: true
+  when: enable_adict

--- a/ansible/roles/mongodb_remove/tasks/main.yml
+++ b/ansible/roles/mongodb_remove/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Stop MongoDB container
+  ansible.builtin.systemd:
+    name: mongodb-{{ app_name }}
+    state: stopped
+    enabled: false
+  failed_when: false
+  tags: uninstall
+
+- name: Remove systemd service file
+  ansible.builtin.file:
+    path: /etc/systemd/system/mongodb-{{ app_name }}.service
+    state: absent
+  tags: uninstall
+
+- name: Remove docker-compose file
+  ansible.builtin.file:
+    path: /data/docker-compose.yml
+    state: absent
+  tags: uninstall
+
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  tags: uninstall

--- a/ansible/roles/nemea_adict/tasks/disable.yml
+++ b/ansible/roles/nemea_adict/tasks/disable.yml
@@ -1,0 +1,30 @@
+---
+- name: Stop modules in supervisor
+  ansible.builtin.command: "{{ item }}"
+  changed_when: true
+  loop:
+    - "supervisorctl stop adict_prefix_filter:"
+    - "supervisorctl stop adict_ip_activity:"
+    - "supervisorctl stop adict_open_ports:"
+    - "supervisorctl stop adict_recog:"
+  tags: configure
+  failed_when: false
+
+- name: Disable NEMEA module groups
+  ansible.builtin.command: supdis -g {{ item }}
+  changed_when: true
+  with_items:
+    - adict_prefix_filter
+    - adict_ip_activity
+    - adict_open_ports
+    - adict_recog
+  tags: configure
+  failed_when: false
+
+- name: Apply changes in supervisor configuration
+  ansible.builtin.command: "{{ item }}"
+  changed_when: true
+  tags: configure
+  loop:
+    - "supervisorctl reread"
+    - "supervisorctl update"

--- a/ansible/roles/nemea_adict/tasks/enable.yml
+++ b/ansible/roles/nemea_adict/tasks/enable.yml
@@ -1,0 +1,22 @@
+---
+- name: Enable NEMEA module groups
+  ansible.builtin.command: supen -d {{ item }} -g {{ item }}
+  changed_when: true
+  with_items:
+    - adict_prefix_filter
+    - adict_ip_activity
+    - adict_open_ports
+    - adict_recog
+  tags: configure
+
+- name: Apply changes in supervisor configuration
+  ansible.builtin.command: "{{ item }}"
+  changed_when: true
+  loop:
+    - "supervisorctl reread"
+    - "supervisorctl update"
+    - "supervisorctl start adict_prefix_filter:"
+    - "supervisorctl start adict_ip_activity:"
+    - "supervisorctl start adict_open_ports:"
+    - "supervisorctl start adict_recog:"
+  tags: configure

--- a/ansible/roles/nemea_adict/tasks/main.yml
+++ b/ansible/roles/nemea_adict/tasks/main.yml
@@ -32,14 +32,14 @@
     mode: "0644"
   tags: configure
 
+  # creates:
+  #   - /etc/nemea_adict/prefix_filter_single
+  #   - /etc/nemea_adict/prefix_filter_bi
+  #   - /etc/nemea_adict/prefixes.conf
 - name: Execute adict configuration generator
   ansible.builtin.command:
     cmd: "{{ pandda_conf_executable }} {{ pandda_conf_opt }}/adict_conf.py {{ pandda_conf_path }}/nemea_adict_filters.yml"
-  args:
-    creates:
-      - /etc/nemea_adict/prefix_filter_single
-      - /etc/nemea_adict/prefix_filter_bi
-      - /etc/nemea_adict/prefixes.conf
+  changed_when: true
   tags: configure
 
 - name: Ensure /etc/nemea_adict/recog directory exists

--- a/ansible/roles/nemea_adict/tasks/main.yml
+++ b/ansible/roles/nemea_adict/tasks/main.yml
@@ -60,24 +60,12 @@
     mode: '0644'
   tags: configure
 
-- name: Enable NEMEA module groups
-  ansible.builtin.command: supen -d {{ item }} -g {{ item }}
-  changed_when: true
-  with_items:
-    - adict_prefix_filter
-    - adict_ip_activity
-    - adict_open_ports
-    - adict_recog
+- name: Disable modules
+  ansible.builtin.include_tasks: disable.yml
+  when: disable_adict
   tags: configure
 
-- name: Apply changes in supervisor configuration
-  ansible.builtin.command: "{{ item }}"
-  changed_when: true
-  loop:
-    - "supervisorctl reread"
-    - "supervisorctl update"
-    - "supervisorctl start adict_prefix_filter:"
-    - "supervisorctl start adict_ip_activity:"
-    - "supervisorctl start adict_open_ports:"
-    - "supervisorctl start adict_recog:"
+- name: Enable modules
+  ansible.builtin.include_tasks: enable.yml
+  when: enable_adict
   tags: configure

--- a/ansible/roles/nemea_adict_remove/tasks/main.yml
+++ b/ansible/roles/nemea_adict_remove/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Stop modules in supervisor
+  ansible.builtin.command: "{{ item }}"
+  changed_when: true
+  loop:
+    - "supervisorctl stop adict_prefix_filter:"
+    - "supervisorctl stop adict_ip_activity:"
+    - "supervisorctl stop adict_open_ports:"
+    - "supervisorctl stop adict_recog:"
+  tags: uninstall
+  failed_when: false
+
+- name: Disable NEMEA module groups
+  ansible.builtin.command: supdis -g {{ item }}
+  changed_when: true
+  with_items:
+    - adict_prefix_filter
+    - adict_ip_activity
+    - adict_open_ports
+    - adict_recog
+  tags: uninstall
+  failed_when: false
+
+- name: Apply changes in supervisor configuration
+  ansible.builtin.command: "{{ item }}"
+  changed_when: true
+  tags: uninstall
+  loop:
+    - "supervisorctl reread"
+    - "supervisorctl update"
+
+- name: Remove /etc/nemea_adict/recog/ directory
+  ansible.builtin.file:
+    name: /etc/nemea_adict/recog/
+    state: absent
+  tags: uninstall
+
+- name: Remove /etc/nemea_adict configuration
+  ansible.builtin.file:
+    name: /etc/nemea_adict/
+    state: absent
+  tags: uninstall
+
+- name: Remove NEMEA ADiCT package
+  ansible.builtin.dnf:
+    name: nemea-adict
+    autoremove: false
+    state: absent
+  tags: uninstall

--- a/ansible/roles/nginx/tasks/disable.yml
+++ b/ansible/roles/nginx/tasks/disable.yml
@@ -1,0 +1,30 @@
+- name: Ensure firewalld is not masked, enabled and running
+  ansible.builtin.systemd:
+    name: firewalld
+    masked: false
+    enabled: true
+    state: started
+  tags: configure
+
+- name: Close ports 80/tcp and 443/tcp
+  ansible.posix.firewalld:
+    port: "{{ item }}/tcp"
+    permanent: true
+    state: disabled
+  tags: configure
+  with_items:
+    - 80
+    - 443
+
+- name: Reload firewalld
+  ansible.builtin.command: firewall-cmd --reload
+  changed_when: true
+  tags: configure
+
+- name: Stop and disable nginx service
+  ansible.builtin.service:
+    name: nginx
+    state: stopped
+    enabled: false
+  tags: configure
+  failed_when: false

--- a/ansible/roles/nginx/tasks/enable.yml
+++ b/ansible/roles/nginx/tasks/enable.yml
@@ -1,0 +1,34 @@
+---
+- name: Restart and enable nginx service
+  ansible.builtin.service:
+    name: nginx
+    state: restarted
+    enabled: true
+  tags: install
+
+- name: Ensure firewalld is not masked, enabled and running
+  ansible.builtin.systemd:
+    name: firewalld
+    masked: false
+    enabled: true
+    state: started
+  tags: install
+
+- name: Open port 80/tcp
+  ansible.posix.firewalld:
+    port: 80/tcp
+    permanent: true
+    state: enabled
+  tags: install
+
+- name: Open port 443/tcp
+  ansible.posix.firewalld:
+    port: 443/tcp
+    permanent: true
+    state: enabled
+  tags: install
+
+- name: Reload firewalld
+  ansible.builtin.command: firewall-cmd --reload
+  changed_when: true
+  tags: install

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -5,6 +5,18 @@
     update_cache: true
   tags: install
 
+- name: Ensure configuration directories exists
+  ansible.builtin.file:
+    path: /etc/{{ item }}
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  with_items:
+    - nginx/
+    - nginx/default.d/
+  tags: configure
+
 - name: Copy configuration
   ansible.builtin.template:
     src: files/{{ item }}
@@ -28,36 +40,12 @@
   ansible.builtin.import_tasks: generate_certs.yml
   tags: configure
 
-- name: Restart and enable nginx service
-  ansible.builtin.service:
-    name: nginx
-    state: restarted
-    enabled: true
-  tags: install
+- name: Disable firewall and nginx
+  ansible.builtin.include_tasks: disable.yml
+  tags: configure
+  when: disable_adict
 
-- name: Ensure firewalld is not masked, enabled and running
-  ansible.builtin.systemd:
-    name: firewalld
-    masked: false
-    enabled: true
-    state: started
-  tags: install
-
-- name: Open port 80/tcp
-  ansible.posix.firewalld:
-    port: 80/tcp
-    permanent: true
-    state: enabled
-  tags: install
-
-- name: Open port 443/tcp
-  ansible.posix.firewalld:
-    port: 443/tcp
-    permanent: true
-    state: enabled
-  tags: install
-
-- name: Reload firewalld
-  ansible.builtin.command: firewall-cmd --reload
-  changed_when: true
-  tags: install
+- name: Enable firewall and nginx
+  ansible.builtin.include_tasks: enable.yml
+  tags: configure
+  when: enable_adict

--- a/ansible/roles/nginx_remove/tasks/main.yml
+++ b/ansible/roles/nginx_remove/tasks/main.yml
@@ -1,0 +1,37 @@
+- name: Ensure firewalld is not masked, enabled and running
+  ansible.builtin.systemd:
+    name: firewalld
+    masked: false
+    enabled: true
+    state: started
+  tags: uninstall
+
+- name: Close ports 80/tcp and 443/tcp
+  ansible.posix.firewalld:
+    port: "{{ item }}/tcp"
+    permanent: true
+    state: disabled
+  tags: uninstall
+  with_items:
+    - 80
+    - 443
+
+- name: Reload firewalld
+  ansible.builtin.command: firewall-cmd --reload
+  changed_when: true
+  tags: uninstall
+
+- name: Stop and disable nginx service
+  ansible.builtin.service:
+    name: nginx
+    state: stopped
+    enabled: false
+  tags: uninstall
+  failed_when: false
+
+- name: Remove nginx
+  ansible.builtin.dnf:
+    name: "nginx"
+    autoremove: false
+    state: absent
+  tags: uninstall

--- a/ansible/roles/rabbitmq/tasks/disable.yml
+++ b/ansible/roles/rabbitmq/tasks/disable.yml
@@ -1,0 +1,8 @@
+---
+- name: Stop and disable rabbitmq-server service
+  ansible.builtin.service:
+    name: rabbitmq-server
+    state: stopped
+    enabled: false
+  failed_when: false
+  tags: configure

--- a/ansible/roles/rabbitmq/tasks/enable.yml
+++ b/ansible/roles/rabbitmq/tasks/enable.yml
@@ -1,0 +1,32 @@
+---
+- name: Start and enable rabbitmq-server service
+  ansible.builtin.service:
+    name: rabbitmq-server
+    state: started
+    enabled: true
+
+- name: Enable web management interface
+  ansible.builtin.command:
+    cmd: rabbitmq-plugins enable rabbitmq_management
+    creates: /etc/rabbitmq/enabled_plugins
+
+- name: Download rabbitmqadmin
+  ansible.builtin.get_url:
+    url: "http://localhost:15672/cli/rabbitmqadmin"
+    dest: "/tmp/rabbitmqadmin"
+    mode: "0755"
+
+- name: Move rabbitmqadmin to /usr/bin
+  ansible.builtin.command: mv /tmp/rabbitmqadmin /usr/bin/
+  args:
+    creates: /usr/bin/rabbitmqadmin
+
+- name: Download rmq_reconfigure.sh script
+  ansible.builtin.get_url:
+    url: "https://raw.githubusercontent.com/CESNET/dp3/master/dp3/scripts/rmq_reconfigure.sh"
+    dest: "/tmp/rmq_reconfigure.sh"
+    mode: "0700"
+
+- name: Run rmq_reconfigure.sh script
+  ansible.builtin.command: sh /tmp/rmq_reconfigure.sh {{ app_name }} {{ workers }}
+  changed_when: true

--- a/ansible/roles/rabbitmq/tasks/main.yml
+++ b/ansible/roles/rabbitmq/tasks/main.yml
@@ -32,34 +32,12 @@
     group: root
     mode: "0644"
 
-- name: Start and enable rabbitmq-server service
-  ansible.builtin.service:
-    name: rabbitmq-server
-    state: started
-    enabled: true
+- name: Stop and disable service
+  ansible.builtin.include_tasks: disable.yml
+  tags: configure
+  when: disable_adict
 
-- name: Enable web management interface
-  ansible.builtin.command:
-    cmd: rabbitmq-plugins enable rabbitmq_management
-    creates: /etc/rabbitmq/enabled_plugins
-
-- name: Download rabbitmqadmin
-  ansible.builtin.get_url:
-    url: "http://localhost:15672/cli/rabbitmqadmin"
-    dest: "/tmp/rabbitmqadmin"
-    mode: "0755"
-
-- name: Move rabbitmqadmin to /usr/bin
-  ansible.builtin.command: mv /tmp/rabbitmqadmin /usr/bin/
-  args:
-    creates: /usr/bin/rabbitmqadmin
-
-- name: Download rmq_reconfigure.sh script
-  ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/CESNET/dp3/master/dp3/scripts/rmq_reconfigure.sh"
-    dest: "/tmp/rmq_reconfigure.sh"
-    mode: "0700"
-
-- name: Run rmq_reconfigure.sh script
-  ansible.builtin.command: sh /tmp/rmq_reconfigure.sh {{ app_name }} {{ workers }}
-  changed_when: true
+- name: Start and enable service
+  ansible.builtin.include_tasks: enable.yml
+  tags: configure
+  when: enable_adict

--- a/ansible/roles/rabbitmq_remove/tasks/main.yml
+++ b/ansible/roles/rabbitmq_remove/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Remove rabbitmqadmin from /usr/bin
+  ansible.builtin.file:
+    path: /usr/bin/rabbitmqadmin
+    state: absent
+  tags: uninstall
+
+- name: Stop and disable rabbitmq-server service
+  ansible.builtin.service:
+    name: rabbitmq-server
+    state: stopped
+    enabled: false
+  failed_when: false
+  tags: uninstall
+
+- name: Remove RabbitMQ and dependencies
+  ansible.builtin.dnf:
+    name: ["erlang", "rabbitmq-server", "socat"]
+    state: absent
+    autoremove: false
+  tags: uninstall
+
+- name: Remove rabbitmq configuration directory
+  ansible.builtin.file:
+    path: /etc/rabbitmq/
+    state: absent
+  tags: uninstall


### PR DESCRIPTION
Four new variables are exposed, meant to be configured using `host_vars`: `remove_adict`, `install_adict`, `enable_adict` and `disable_adict`. All variables default to `false`, except `enable_adict`, which defaults to the value of `install_adict` when undefined.

The installation of the `dp3`, `pandda_gui` and `nemea_adict` is conditioned on these variables, and is hidden under a new role `adict`. New roles were introduced to process the removal of these roles.

The executed logic can be simplified as:
```py
if remove_adict:
    process_removal()
if install_adict:
    process_install()
    if disable_adict:
        process_disable()
    if enable_adict:
        process_enable()
```