### PR TITLE
perf(pandda_conf): set htpasswd bcrypt cost to 9

### DIFF
--- a/ansible/roles/pandda_conf/files/adict_basic_auth_conf.py
+++ b/ansible/roles/pandda_conf/files/adict_basic_auth_conf.py
@@ -19,7 +19,12 @@ def generate_htpasswd_content(config: dict, output_file: typing.TextIO):
         password = user["password"]
 
         # Hash password using htpasswd's bcrypt mechanism
-        hash_salt = bcrypt.gensalt()
+        # Cost of 9 is a compromise between security and performance.
+        # Default cost of 12 takes about 200 ms for each HTTP request in nginx,
+        # because HTTP basic auth is stateless.
+        # By using cost of 9, we can reduce this time to about 25 ms
+        # (or about 1 second for a batch of 32 requests in parallel).
+        hash_salt = bcrypt.gensalt(rounds=9)
         hashed_password = bcrypt.hashpw(password.encode("utf-8"), hash_salt).decode("utf-8")
 
         f.write(f"{username}:{hashed_password}\n")


### PR DESCRIPTION
This change aims increasing perfomance of nginx requests processing and decreasing wait times. Waiting 8 seconds for a single batch of 32 IP addresses in IP subnet summary is simply too long.

From the security perspective, once someone gains access to the server with the password hash, they can just bypass the authentication altogether. Cost of 9 seems to be a good compromise between required speed and brute-force resistancy.