### PR TITLE
feat(nemea_adict): use updated IP activity module

### DIFF
--- a/ansible/roles/nemea_adict/files/configs/adict_ip_activity/ip_activity.ini
+++ b/ansible/roles/nemea_adict/files/configs/adict_ip_activity/ip_activity.ini
@@ -1,9 +1,9 @@
 [program:ip_activity_process]
-command=/usr/bin/nemea_adict/ip_activity2.py
+command=/usr/bin/nemea_adict/ip_activity.py
         -s "ip_activity@collector-pandda"
         --interval 600
         --maxage 900
-        -i "u:adict_filter_outgoing,u:ip_activity_datapoints"
+        -i "u:adict_filter,u:ip_activity_datapoints"
         --networks-file "/etc/nemea_adict/prefixes.conf"
 process_name=%(program_name)s ; process_name expr (default %(program_name)s)
 ;numprocs=1                    ; number of processes copies to start (def 1)


### PR DESCRIPTION
New IP activity module measures both incoming and outgoing traffic.

See: https://github.com/CESNET/Pandda-ADiCT/pull/29

Should be merged after a new version of PANDDA-ADiCT is released, because files have been renamed and the installation would be broken.