### PR TITLE
Fix flow collection in Vagrant test environment

### DIFF
--- a/ansible/inventory/host_files/192.168.56.11/pandda.yaml
+++ b/ansible/inventory/host_files/192.168.56.11/pandda.yaml
@@ -15,8 +15,8 @@
         - vlan
         - pstats: [includezeroes, skipdup]
       output:
-        link: true
-        dir: false
+        link: 1
+        dir: 0
         host: 192.168.56.10
         port: 4739
         udp: true
@@ -38,8 +38,8 @@
         - vlan
         - pstats: [includezeroes, skipdup]
       output:
-        link: true
-        dir: false
+        link: 1
+        dir: 0
         host: 192.168.56.10
         port: 4739
         udp: true

--- a/ansible/inventory/host_files/192.168.56.11/pandda.yaml
+++ b/ansible/inventory/host_files/192.168.56.11/pandda.yaml
@@ -19,7 +19,7 @@
         dir: 0
         host: 192.168.56.10
         port: 4739
-        udp: true
+        udp: false
         template_refresh_rate: 60
 
     - instance_name: raw_eth1
@@ -42,5 +42,5 @@
         dir: 0
         host: 192.168.56.10
         port: 4739
-        udp: true
+        udp: false
         template_refresh_rate: 60


### PR DESCRIPTION
Fixes two issues in configuration of metering point of Vagrant test environment.

1. Output link and direction are expected to be either 0 or 1.
   Boolean literals (`true` and `false`) cause crash of ipfixprobe instances during start,
   so there are no flows exported as a result.

2. Until now, metering point exported flows to UDP port,
   but the collector is listening on TCP port, so once again,
   there were no flows on the collector.